### PR TITLE
Fixed Makefile typos

### DIFF
--- a/daos-cortx/src/daos_kv_benchmark/makefile
+++ b/daos-cortx/src/daos_kv_benchmark/makefile
@@ -1,9 +1,10 @@
 CC=/opt/rh/devtoolset-7/root/usr/bin/g++ #use your own path
 daos_dir=/root/src_daos/daos
 benchmark_dir=/root/google_benchmark
-CFLAGS=-I$(daos_dir)/src/include
-LIBDIR=-L(benchmark_dir)/benchmark/build/src -L${daos_dir}/install/lib64
+CFLAGS=-I${daos_dir}/src/include
+LIBDIR=-L${benchmark_dir}/benchmark/build/src -L${daos_dir}/install/lib64
 LIBS=-lpthread -lbenchmark -ldaos -lgurt -ldaos_common -luuid
 
-daos_benchmark : kv_benchmark.cc
-        $(CC) -o $@ $^ -std=c++11 -isystem benchmark/include $(CFLAGS) $(LIBDIR) $(LIBS)
+#Recipe line starts with a single TAB
+daos_benchmark : kv_benchmarking.cc
+        ${CC} -o $@ $^ -std=c++11 -isystem benchmark/include ${CFLAGS} ${LIBDIR} ${LIBS}

--- a/daos-cortx/src/daos_kv_benchmark/makefile
+++ b/daos-cortx/src/daos_kv_benchmark/makefile
@@ -5,6 +5,6 @@ CFLAGS=-I${daos_dir}/src/include
 LIBDIR=-L${benchmark_dir}/benchmark/build/src -L${daos_dir}/install/lib64
 LIBS=-lpthread -lbenchmark -ldaos -lgurt -ldaos_common -luuid
 
-#Recipe line starts with a single TAB
+#Recipe line starts with a single tab
 daos_benchmark : kv_benchmarking.cc
-        ${CC} -o $@ $^ -std=c++11 -isystem benchmark/include ${CFLAGS} ${LIBDIR} ${LIBS}
+        ${CC} -o $@ $^ -std=c++11 -isystem ${benchmark_dir}/benchmark/include ${CFLAGS} ${LIBDIR} ${LIBS}


### PR DESCRIPTION
Fix input file name [kv_benchmark.cc -> kv_benchmarking.cc]
Fix makefile variable dereferencing by adding dollar sign.