### PR TITLE
Helper scripts for regression testing of cortx-k8s

### DIFF
--- a/K8s-Orch-Tools/jira_common.py
+++ b/K8s-Orch-Tools/jira_common.py
@@ -26,11 +26,10 @@ def query(jql, querydict=None):
 
     querystring = ''
     if querydict:
-        querystring = '&'.join(['%s=%s'%(k,v) for k,v in list(querydict.items())]) + '&'
+        querystring = '&'.join([f'{k}={v}' for k,v in list(querydict.items())]) + '&'
 
 
-    url = "https://jts.seagate.com/rest/api/2/search?%sjql=%s" % (querystring, jql)
-    #url = "https://jts.seagate.com/rest/api/2/search?%sjql=%s&expand=changelog" % (querystring, jql)
+    url = f"https://jts.seagate.com/rest/api/2/search?{querystring}jql={jql}"
 
     auth = userauth()
     headers = {
@@ -46,7 +45,7 @@ def query(jql, querydict=None):
             break
         except Exception as e:
             retry_count += 1
-            print("Exception caught: %s.  Retrying (%d)." % (str(e), retry_count))
+            print(f"Exception caught: {e}.  Retrying ({retry_count}).")
 
     if r.status_code != 200:
         raise FailedJqlException(r.text)
@@ -57,21 +56,20 @@ def query_all(jql, querydict=None, verbose=True):
     # Take care of pagination of all queries.  Return a list of issues.
 
     result = []
-    startAt = 0
-    maxResults = 100
+    start_at = 0
+    max_results = 100
     while True:
         if not querydict:
             querydict = {}
-        querydict.update({'startAt': startAt, 'maxResults': maxResults})
+        querydict.update({'startAt': start_at, 'maxResults': max_results})
         qout = query(jql, querydict=querydict)
-        f = open("qout.debug", "w")
-        f.write(json.dumps(qout))
-        f.close()
+        with open("qout.debut", "w") as f:
+            f.write(json.dumps(qout))
 
         result += qout['issues']
         if verbose:
-            print("Got %d issues so far" % len(result), file=sys.stderr)
-        if startAt + len(qout['issues']) >= qout['total']:
+            print("Got {len(result)} issues so far", file=sys.stderr)
+        if start_at + len(qout['issues']) >= qout['total']:
             break
-        startAt += len(qout['issues'])
+        start_at += len(qout['issues'])
     return result

--- a/K8s-Orch-Tools/jira_common.py
+++ b/K8s-Orch-Tools/jira_common.py
@@ -18,6 +18,7 @@ def userauth():
 
 class FailedJqlException(Exception):
     def __init__(self, message):
+        '''Helper exception'''
         super().__init__(message)
 
 

--- a/K8s-Orch-Tools/jira_common.py
+++ b/K8s-Orch-Tools/jira_common.py
@@ -1,0 +1,76 @@
+#!/usr/bin/python3
+
+import requests
+import json
+import sys
+import os
+import time
+
+
+username = os.environ['JIRA_USERNAME']
+password = os.environ['JIRA_PASSWORD']
+
+IMGURL = '/static/img'
+
+
+def userauth():
+    return (username, password)
+
+class FailedJqlException(Exception):
+    def __init__(self, message):
+        super().__init__(message)
+
+
+def query(jql, querydict=None):
+
+    querystring = ''
+    if querydict:
+        querystring = '&'.join(['%s=%s'%(k,v) for k,v in list(querydict.items())]) + '&'
+
+
+    url = "https://jts.seagate.com/rest/api/2/search?%sjql=%s" % (querystring, jql)
+    #url = "https://jts.seagate.com/rest/api/2/search?%sjql=%s&expand=changelog" % (querystring, jql)
+
+    auth = userauth()
+    headers = {
+       "Accept": "application/json",
+       "Content-Type": "application/json",
+    }
+
+    retry_count = 0
+    while True:
+        try:
+            print("%s GET %s" % (time.ctime(), url), file=sys.stderr)
+            r = requests.get(url, auth=auth, headers=headers)
+            break
+        except Exception as e:
+            retry_count += 1
+            print("Exception caught: %s.  Retrying (%d)." % (str(e), retry_count))
+
+    if r.status_code != 200:
+        raise FailedJqlException(r.text)
+
+    return json.loads(r.text)
+
+def query_all(jql, querydict=None, verbose=True):
+    # Take care of pagination of all queries.  Return a list of issues.
+
+    result = []
+    startAt = 0
+    maxResults = 100
+    while True:
+        if not querydict:
+            querydict = {}
+        querydict.update({'startAt': startAt, 'maxResults': maxResults})
+        qout = query(jql, querydict=querydict)
+        f = open("qout.debug", "w")
+        f.write(json.dumps(qout))
+        f.close()
+
+        result += qout['issues']
+        if verbose:
+            print("Got %d issues so far" % len(result), file=sys.stderr)
+        if startAt + len(qout['issues']) >= qout['total']:
+            break
+        startAt += len(qout['issues'])
+    return result

--- a/K8s-Orch-Tools/jira_common.py
+++ b/K8s-Orch-Tools/jira_common.py
@@ -41,7 +41,7 @@ def query(jql, querydict=None):
     retry_count = 0
     while True:
         try:
-            print("%s GET %s" % (time.ctime(), url), file=sys.stderr)
+            print(f"{time.ctime()} GET {url}", file=sys.stderr)
             r = requests.get(url, auth=auth, headers=headers)
             break
         except Exception as e:

--- a/K8s-Orch-Tools/post_jenkins_result.py
+++ b/K8s-Orch-Tools/post_jenkins_result.py
@@ -1,0 +1,89 @@
+#!/usr/bin/python3 -u
+
+############################################################
+#
+# Note: This is a work in progress.
+#
+############################################################
+
+import argparse
+import requests
+import os
+from pprint import pprint
+
+import jira_common
+
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-j', '--jira-issue', required=True)
+    parser.add_argument('-r', '--jenkins-result', required=True)
+    args = parser.parse_args()
+
+    url = f"https://jts.seagate.com/rest/api/2/issue/{args.jira_issue}/attachments"
+    print(url)
+
+    auth = jira_common.userauth()
+    headers = {
+       "X-Atlassian-Token": "nocheck"
+    }
+
+    zipfile = args.jenkins_result + '.zip'
+    zipfile_base = os.path.basename(zipfile)
+    ziptarget = os.path.basename(args.jenkins_result)
+    zip_working_dir = os.path.dirname(zipfile)
+    print(f"Zipping result into {zipfile}:")
+    cmd = f'cd {zip_working_dir}; zip -r {zipfile_base} {ziptarget}'
+    print(cmd)
+    os.system(f'cd {zip_working_dir}; zip -r {zipfile} {args.jenkins_result}')
+
+    print(f"Posting file {zipfile} to {url}")
+    r = requests.post(url, auth=auth, headers=headers, files={'file': open(zipfile, 'rb')})
+    data = r.json()
+    pprint(data)
+    attachment_url = data[0]['content']
+
+    os.unlink(zipfile)
+
+
+    #
+    # Upload test comment
+    #
+    # TODO: remove this hardcoded file, replace with args.jenkins_Result
+    filesummary = "/tmp/setup-cortx-cluster-solution-input_357/summary.txt"
+    headers = {"Content-Type": "application/json"}
+
+    # For the content of the summary file, I want to print the first three
+    # lines as plain text, and the remaining lines as a code block.
+
+    file_content = open(filesummary).read()
+    file1, file2 = file_content.split('\n\n')
+
+    content = '*Code tested*\n\n'
+    content += file1 + '\n'
+    content += '{code}\n'
+    content += file2 + '\n'
+    content += '{code}\n'
+    content += f'\n[See attached logs|{attachment_url}]\n'
+
+    print("content ---------------------------------")
+    print(content)
+    print("------------------------------------------")
+
+    data = {
+             "update": {
+               "comment": [
+                 {
+                   "add": {
+                     "body": content
+                   }
+                 }
+               ]
+             }
+           }
+
+    url = f"https://jts.seagate.com/rest/api/2/issue/{args.jira_issue}"
+    r = requests.put(url, auth=auth, headers=headers, json=data)
+    print(r.status_code)
+

--- a/K8s-Orch-Tools/post_jenkins_result.py
+++ b/K8s-Orch-Tools/post_jenkins_result.py
@@ -9,7 +9,7 @@
 import argparse
 import requests
 import os
-from pprint import pprint
+import pprint
 
 import jira_common
 
@@ -41,7 +41,7 @@ if __name__ == '__main__':
     print(f"Posting file {zipfile} to {url}")
     r = requests.post(url, auth=auth, headers=headers, files={'file': open(zipfile, 'rb')})
     data = r.json()
-    pprint(data)
+    pprint.pprint(data)
     attachment_url = data[0]['content']
 
     os.unlink(zipfile)
@@ -59,12 +59,14 @@ if __name__ == '__main__':
     file_content = open(filesummary).read()
     file1, file2 = file_content.split('\n\n')
 
-    content = '*Code tested*\n\n'
-    content += file1 + '\n'
-    content += '{code}\n'
-    content += file2 + '\n'
-    content += '{code}\n'
-    content += f'\n[See attached logs|{attachment_url}]\n'
+    content = f'''*Code tested*
+{file1}
+{{code}}
+{file2}
+{{code}}
+
+[See attached logs|{attachment_url}]
+'''
 
     print("content ---------------------------------")
     print(content)

--- a/K8s-Orch-Tools/post_jenkins_result.py
+++ b/K8s-Orch-Tools/post_jenkins_result.py
@@ -50,8 +50,7 @@ if __name__ == '__main__':
     #
     # Upload test comment
     #
-    # TODO: remove this hardcoded file, replace with args.jenkins_Result
-    filesummary = "/tmp/setup-cortx-cluster-solution-input_357/summary.txt"
+    filesummary = os.path.join(args.jenkins_result, "summary.txt")
     headers = {"Content-Type": "application/json"}
 
     # For the content of the summary file, I want to print the first three

--- a/K8s-Orch-Tools/trigger_jenkins.py
+++ b/K8s-Orch-Tools/trigger_jenkins.py
@@ -60,7 +60,6 @@ import datetime
 import re
 import os
 import sys
-import tempfile
 import time
 
 from yaml import load, Loader

--- a/K8s-Orch-Tools/trigger_jenkins.py
+++ b/K8s-Orch-Tools/trigger_jenkins.py
@@ -1,0 +1,256 @@
+#!/usr/bin/python3 -u
+
+########################################################
+# trigger_jenkins.py
+#
+# This script triggers the jenkins job setup-cortx-cluster-solution-input,
+# which is a simple sanity test that is useful to run prior to merging
+# changes.  This job collects logs and artifacts that may be useful in
+# updating your Jira issue.
+#
+# The job runs on your own Kubernetes cluster.  It assumes
+# that it is ready for CORTX deployment, which means that
+# "prereq-deploy-cortx-cloud.sh" has already been run and
+# CORTX is not currently running.
+#
+#
+#
+# Usage:  trigger_jenkins.py <options>
+# 
+#  -s <solution.yaml>  The solution.yaml file that describes your cluster.
+#                    This file will be uploaded to the Jenkins job, which
+#                    copies it to /var/tmp/solution.yaml on the first node
+#                    listed.  This file determines which cortx-all package
+#                    will be used.
+#
+#  -t <tag>  This is the git changeset of the seagate/cortx-k8s repo to use.
+#                    This can be a tag (like v0.0.21) or a sha.
+#
+#  Jenkins token
+#  -------------
+#  Your Jenkins token must be provided to run the Jenkins job.  The Jenkins user
+#  and token must be in the format <user>:<token>.  These may be specified via
+#  command line as -u <user>:<token>, or through the environment variable
+#  JENKINS_USER_TOKEN.
+#
+#  Node access
+#  -----------
+#  The Jenkins job accesses the nodes via ssh.  This script assumes that the
+#  username and password are identical for all nodes.  You specify the password
+#  via command line as -p <password>, or throught the environment variable
+#  NODE_PASSWORD.
+#
+#  By default the username is "root", but this can be overridden via the command
+#  line as "--node-user <username>".
+#
+#
+# Script Output
+# =============
+# After the Job has been run, the artifacts created by the job, the
+# console output, and a summary suitable for pasting into a report
+# are created in /tmp/setup-cortx-cluster-solution-input_<build-number>.
+#
+#
+########################################################
+
+
+
+import argparse
+import datetime
+import re
+import os
+import sys
+import time
+
+from yaml import load, Loader
+import requests
+
+
+
+
+
+JENKINS_JOB = "http://eos-jenkins.colo.seagate.com/job/Cortx-Kubernetes/job/setup-cortx-cluster-solution-input"
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-s', '--solution', dest='solution_file', required=True)
+parser.add_argument('-t', '--tag', dest='cortx_k8s_tag', required=True)
+parser.add_argument('--node-user', dest='node_user', default='root')
+parser.add_argument('-p', '--node-password', dest='node_password')
+parser.add_argument('-u', '--user-token', dest='user_token')
+#Note: For --debug-skip-trigger, the arg shuld be the build url
+#      For example:  "http://eos-jenkins.colo.seagate.com/job/Cortx-kubernetes/job/setup-cortx-cluster-solution-input/341/"
+parser.add_argument('--debug-skip-trigger', dest='debug_skip_trigger')
+
+args = parser.parse_args()
+
+if not args.user_token:
+    args.user_token = os.environ.get('JENKINS_USER_TOKEN')
+    if not args.user_token:
+        print("No Jenkins user token specified.", file=sys.stderr)
+        print('  Specify with -u/--user-token or with', file=sys.stderr)
+        print('  the environment variable "JENKINS_USER_TOKEN"', file=sys.stderr)
+        sys.exit(1)
+
+if not re.match('\w+:\w+', args.user_token):
+    print(f"Invalid Jenkins user token specified ({args.user_token}).", file=sys.stderr)
+    print("The user token should have the form \"<jenkins-username>:<jenkins-token>\".", file=sys.stderr)
+    sys.exit(1)
+
+username, password = args.user_token.split(':')
+
+if not args.node_password:
+    args.node_password = os.environ.get('NODE_PASSWORD')
+    if not args.node_password:
+        print('No password for cortx nodes specified.', file=sys.stderr)
+        print('  Specify with -p/--node-password or with', file=sys.stderr)
+        print('  the environment variable "NODE_PASSWORD"', file=sys.stderr)
+        sys.exit(1)
+
+#
+# Read hostnames from solution.yaml
+#
+if not os.path.exists(args.solution_file):
+    print("File {args.solution_file} does not exist.", file=sys.stderr)
+    sys.exit(1)
+
+solution_content = load(open(args.solution_file), Loader=Loader)
+nodes = solution_content['solution']['nodes']
+hosts = [f"hostname={n['name']},user={args.node_user},password={args.node_password}" for n in nodes.values()]
+
+jenkins_build_url = JENKINS_JOB+'/buildWithParameters'
+
+hosts0 = hosts[0]
+hosts_other = '\n'.join(['                       '+h for h in hosts[1:]])
+dashboard_header = f"""command = {' '.join(sys.argv)}
+                user = {username}
+CORTX_SCRIPTS_BRANCH = {args.cortx_k8s_tag}
+ input/solution.yaml = {args.solution_file}
+               hosts = {hosts[0]}
+{hosts_other}"""
+
+print("*********************************************")
+print(f"Triggering Jenkins: {jenkins_build_url}")
+print()
+print(dashboard_header)
+print("*********************************************")
+
+
+if not args.debug_skip_trigger:
+
+    r = requests.post(jenkins_build_url, auth=(username, password),
+                      data={'CORTX_SCRIPTS_BRANCH': args.cortx_k8s_tag,
+                            'hosts': ' '.join(hosts)},
+                      files={'input/solution.yaml': open(args.solution_file, "rb")})
+
+    queue_item_url = r.headers['Location']
+
+    #
+    # Wait for job to execute
+    #
+
+
+    print(f"Job triggered.  Jenkins queue item: {queue_item_url}")
+    print("Waiting for job to start.")
+
+    queue_item_url += 'api/json'
+    while True:
+        r = requests.get(queue_item_url)
+        if r.status_code == 200:
+            build_data = r.json()
+            if 'executable' in build_data:
+                break
+        time.sleep(1)
+
+
+    build_url = build_data['executable']['url']
+else:
+    build_url = args.debug_skip_trigger
+
+
+
+r = requests.get(build_url+'/api/json')
+
+print("\n\nJob started.  Waiting for job to complete")
+print(f"Jenkins url: {build_url}\n")
+
+
+jobstarted = datetime.datetime.now()
+job_started_str = jobstarted.strftime("%Y-%m-%d/%H:%M:%S")
+datetimer = 0
+dateprinttime = 60  #every minute
+while True:
+    nowtime = time.time()
+    now = datetime.datetime.now()
+    if nowtime - datetimer > dateprinttime:
+        now_str = datetime.datetime.now().strftime("%Y-%m-%d/%H:%M:%S")
+        elapsed = (now - jobstarted).seconds
+        elapsed_str = f"{elapsed//60}m {elapsed%60}s"
+        print(f"Job running:   started: {job_started_str}    now: {now_str}     elapsed: {elapsed_str}")
+        datetimer = nowtime
+
+    r = requests.get(build_url+'/api/json')
+    if r.status_code != 200:
+        print(f"Error: Could not contact Jenkins server at {build_url+'/api/json'}")
+        continue
+
+
+    builddata = r.json()
+    result = builddata['result']
+    if result:
+        now_str = datetime.datetime.now().strftime("%Y-%m-%d/%H:%M:%S")
+        elapsed = (now - jobstarted).seconds
+        elapsed_str = f"{elapsed//60}m {elapsed%60}s"
+        print(f"Job completed: started: {job_started_str}    now: {now_str}     elapsed: {elapsed_str}")
+        break
+
+    time.sleep(5)
+
+
+if result == 'SUCCESS':
+    print("\n\nJob Succeeded! \n\n")
+
+else:
+    print(f"\n\nJob did not pass: {result}\n\n")
+
+#
+# Download all artifacts
+#
+m = re.search(r'.+/([\w\-]+)/(\d+)/$', builddata['url'])
+artifactdir = f"/tmp/{m.group(1)}_{m.group(2)}"
+
+if not os.path.isdir(artifactdir):
+    os.mkdir(artifactdir)
+
+for artifact in builddata['artifacts']:
+    print(f"Downloading artifact: {artifactdir}/{artifact['fileName']}")
+    r = requests.get(build_url+f"artifact/{artifact['relativePath']}")
+    f = open(os.path.join(artifactdir, artifact['fileName']), 'wb')
+    f.write(r.content)
+    f.close()
+
+logname = 'console.log'
+print(f"Downloading log: {artifactdir}/{logname}")
+
+log_url = f"{builddata['url']}timestamps/?time=HH:mm:ss&timeZone=GMT-8&appendLog&locale=en"
+r = requests.get(log_url)
+f = open(os.path.join(artifactdir, logname), 'wb')
+f.write(r.content)
+f.close()
+
+summary_filename = 'summary.txt'
+print(f"Writing summary: {artifactdir}/{summary_filename}")
+f = open(os.path.join(artifactdir, summary_filename), 'w')
+print(f"Build: {build_url}", file=f)
+print(f"Completed at {time.ctime()}", file=f)
+print(f"Result = {result}", file=f)
+print('', file=f)
+summary_hidden_pw = re.sub(r'password=[^\s]+', 'password=<hidden>', dashboard_header)
+print(summary_hidden_pw, file=f)
+f.close()
+
+print("\nDone! \n")
+
+if result == 'SUCCESS':
+    sys.exit(0)
+else:
+    sys.exit(1)

--- a/K8s-Orch-Tools/trigger_jenkins.py
+++ b/K8s-Orch-Tools/trigger_jenkins.py
@@ -138,7 +138,7 @@ print("*********************************************")
 if not args.debug_skip_trigger:
 
     r = requests.post(jenkins_build_url, auth=(username, password),
-                      verify=False,
+                      verify=False,   # NOSEC
                       data={'CORTX_SCRIPTS_BRANCH': args.cortx_k8s_tag,
                             'hosts': ' '.join(hosts)},
                       files={'input/solution.yaml': open(args.solution_file, "rb")})
@@ -155,7 +155,7 @@ if not args.debug_skip_trigger:
 
     queue_item_url += 'api/json'
     while True:
-        r = requests.get(queue_item_url, verify=False)
+        r = requests.get(queue_item_url, verify=False)   # NOSEC
         if r.status_code == 200:
             build_data = r.json()
             if 'executable' in build_data:
@@ -169,7 +169,7 @@ else:
 
 build_url = build_url.replace('http:', 'https:')
 
-r = requests.get(build_url+'/api/json', verify=False)
+r = requests.get(build_url+'/api/json', verify=False)   # NOSEC
 
 print("\n\nJob started.  Waiting for job to complete")
 print(f"Jenkins url: {build_url}\n")
@@ -189,7 +189,7 @@ while True:
         print(f"Job running:   started: {job_started_str}    now: {now_str}     elapsed: {elapsed_str}")
         datetimer = nowtime
 
-    r = requests.get(build_url+'/api/json', verify=False)
+    r = requests.get(build_url+'/api/json', verify=False)   # NOSEC
     if r.status_code != 200:
         print(f"Error: Could not contact Jenkins server at {build_url+'/api/json'}")
         continue
@@ -224,7 +224,7 @@ if not os.path.isdir(artifactdir):
 
 for artifact in builddata['artifacts']:
     print(f"Downloading artifact: {artifactdir}/{artifact['fileName']}")
-    r = requests.get(build_url+f"artifact/{artifact['relativePath']}", verify=False)
+    r = requests.get(build_url+f"artifact/{artifact['relativePath']}", verify=False)   # NOSEC
     f = open(os.path.join(artifactdir, artifact['fileName']), 'wb')
     f.write(r.content)
     f.close()
@@ -233,7 +233,7 @@ logname = 'console.log'
 print(f"Downloading log: {artifactdir}/{logname}")
 
 log_url = f"{builddata['url']}timestamps/?time=HH:mm:ss&timeZone=GMT-8&appendLog&locale=en"
-r = requests.get(log_url, verify=False)
+r = requests.get(log_url, verify=False)   # NOSEC
 f = open(os.path.join(artifactdir, logname), 'wb')
 f.write(r.content)
 f.close()


### PR DESCRIPTION
These scripts are scripts that help me automate some of my personal regression testing for cortx-k8s.  These are not appropriate to put into the cortx-k8s repo because they are reliant on Seagate internal servers.  But it is important to put these somewhere accessible by others.

trigger_jenkins.py:  Script to trigger a CICD job that does a basic CORTX deploy + IO
post_jenkins_result.py:  Script to post to Seagate Jira (for evidence of test)
